### PR TITLE
Index (in the migration) issue

### DIFF
--- a/lib/generators/localized_fields/templates/migration.rb
+++ b/lib/generators/localized_fields/templates/migration.rb
@@ -1,16 +1,16 @@
 class CreateLocalizedFields < ActiveRecord::Migration
   def self.up
-       create_table :localized_fields do |t|
-         t.string :localized_object_type
-         t.integer :localized_object_id
-         t.string :locale
-         t.string :field_name
-         t.text :value
-         #Any additional fields here
+    create_table :localized_fields do |t|
+      t.string :localized_object_type
+      t.integer :localized_object_id
+      t.string :locale
+      t.string :field_name
+      t.text :value
+      #Any additional fields here
 
-         t.timestamps
-      end
-      add_index :localized_fields,[:localized_object_type,:localized_object_type_id]
+      t.timestamps
+    end
+    add_index :localized_fields,[:localized_object_type,:localized_object_id], :name => 'index_localized_fields_on_object_type_and_id'
   end
 
   def self.down


### PR DESCRIPTION
On MySQL: `mysql  Ver 14.14 Distrib 5.5.10, for osx10.6 (i386) using  EditLine wrapper`, using the `mysql2` gem in Rails 3.0.7 I received:

```
-- add_index(:localized_fields, [:localized_object_type, :localized_object_type_id])
rake aborted!
An error has occurred, all later migrations canceled:

Index name 'index_localized_fields_on_localized_object_type_and_localized_object_type_id' on table 'localized_fields' is too long; the limit is 64 characters
```

I fixed that by appending an `:name => 'shorter_name'`, and then noticed that `:localized_object_type_id` should be `:localized_object_id`. BAM! It works. 

I started to try to get the tests running, and then I sort of gave up after I got all the gems installed and `rake test` broke. Haha. Then I opened up the test and realized there aren't any anyway. All that `gem install`ing for nothing! ;-)
